### PR TITLE
Fix window.removeEventListener call

### DIFF
--- a/src/lib/ReactSiema.js
+++ b/src/lib/ReactSiema.js
@@ -71,7 +71,7 @@ class ReactSiema extends Component {
     }
 
     componentWillUnmount() {
-        window.removeEventListener(this.onResize);
+        window.removeEventListener('resize', this.onResize);
     }
 
     init() {


### PR DESCRIPTION
This method takes 2 parameters.

https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener.

Raised in https://github.com/Kaveckas/react-siema/issues/2